### PR TITLE
Using the latest version of plugin-publish

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -14,7 +14,7 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7'
-    id 'com.gradle.plugin-publish' version '0.9.6'
+    id 'com.gradle.plugin-publish' version '0.10.1'
 }
 
 group 'com.flurry'


### PR DESCRIPTION
We have been having issue with publishing the latest gradle plugin to the gradle plugin repo.
This was due to a bug with the publish plugin that is explained in this link.
https://discuss.gradle.org/t/weird-fail-on-plugins-gradle-org-enunciate-2-10-0/24573