### PR TITLE
Using the latest gradle api

### DIFF
--- a/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
+++ b/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
@@ -59,6 +59,7 @@ class NdkSymbolUpload {
         try {
             variant.getExternalNativeBuildProviders().each { taskProvider -> searchForSharedObjectFiles(taskProvider.get()) }
         } catch(Throwable ignored) {
+            // The catch block is a fallback in case if the gradle version does not support the Provider API
             variant.externalNativeBuildTasks.each { task -> searchForSharedObjectFiles(task) }
         }
         

--- a/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
+++ b/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
@@ -57,7 +57,11 @@ class NdkSymbolUpload {
         }
 
         try {
-            variant.getExternalNativeBuildProviders().each { taskProvider -> searchForSharedObjectFiles(taskProvider.get()) }
+            variant.getExternalNativeBuildProviders().each {
+                it.configure() {
+                    searchForSharedObjectFiles(it)
+                }
+            }
         } catch(Throwable ignored) {
             // The catch block is a fallback in case if the gradle version does not support the Provider API
             variant.externalNativeBuildTasks.each { task -> searchForSharedObjectFiles(task) }

--- a/gradle/src/main/groovy/com/flurry/android/symbols/SymbolUploadPlugin.groovy
+++ b/gradle/src/main/groovy/com/flurry/android/symbols/SymbolUploadPlugin.groovy
@@ -56,6 +56,7 @@ class SymbolUploadPlugin implements Plugin<Project> {
                             it.doFirst { uploadMappingFile() }
                         }
                     } catch (Throwable ignored) {
+                        // The catch block is a fallback in case if the gradle version does not support the Provider API
                         variant.assemble.doFirst { uploadMappingFile() }
                     }
                 }
@@ -73,6 +74,7 @@ class SymbolUploadPlugin implements Plugin<Project> {
                         }
                     }
                 } catch (Throwable ignored) {
+                    // The catch block is a fallback in case if the gradle version does not support the Provider API
                     variant.assemble.doLast {
                         uploadNDKSymbols()
                     }


### PR DESCRIPTION
This PR fixes the following issue by using the latest api calls.
https://github.com/flurry/upload-clients/issues/19

The changes follow a pattern similar to what is done in the bugsnag plugin
https://github.com/bugsnag/bugsnag-android-gradle-plugin/pull/146
and suggested in the following link
https://inneka.com/programming/android/while-android-studio-updated-to-v3-3-getting-api-variant-getassemble-is-obsolete-and-has-been-replaced-with-variant-getassembleprovider/

Testing:

I am using my test project for testing. Following are the logs for the gradel commands using the standard plugin and the plugin with the changes in the PR. I was not able to see the warning while using the version of the plugin built from this PR's branch.

https://git.ouroath.com/gist/suriyasundar/152ccb6d10af78aad94121057fdac2d9
https://git.ouroath.com/gist/suriyasundar/e5dbcf88d51cdb938097da1e52766b95

Also verified that the symbol files are uploaded to s3.