### PR TITLE
Revert "Revise android plugin version to 4.x"

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath "com.gradle.publish:plugin-publish-plugin:0.14.0"
+        classpath "com.gradle.publish:plugin-publish-plugin:0.9.6"
     }
 }
 
@@ -14,11 +14,11 @@ plugins {
     id 'java'
     id 'maven-publish'
     id 'com.jfrog.bintray' version '1.7'
-    id 'com.gradle.plugin-publish' version '0.14.0'
+    id 'com.gradle.plugin-publish' version '0.10.1'
 }
 
 group 'com.flurry'
-version '4.0.0'
+version '3.0.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'com.android.tools.build:gradle:[4.2.0,5.0)'
+    compileOnly 'com.android.tools.build:gradle:[3.6.4,4.0)'
 
     compile gradleApi()
     compile localGroovy()


### PR DESCRIPTION
Reverts flurry/upload-clients#35

We are reverting because we found out an issue with the version 3.0.0 that was released.

We need to fix the issue in the version 3.0.0 and release 3.1.0 before moving on to 4.0.0

