### PR TITLE
Use os.walk rather than os.listdir to find dsym folders.

### DIFF
--- a/xcode/upload-symbols-py3.py
+++ b/xcode/upload-symbols-py3.py
@@ -173,7 +173,6 @@ def lookup_api_key(apikey, token):
     log.debug("project: %s", project)
     return int(project["data"][0]["id"])
 
-
 def tar_gz_dsyms(search_path, single_file):
     """Tar and gz all of the dSYMs found in the provided directory
     search_path - the path of the dSYM root
@@ -185,19 +184,23 @@ def tar_gz_dsyms(search_path, single_file):
 
     search_root = os.path.abspath(search_path)
     if single_file:
-        dsyms = [os.path.basename(search_root)]
+        dsyms = [os.path.split(search_root)]
         search_root = os.path.dirname(search_root)
     else:
         log.debug("looking for dsyms in %s", search_root)
-        dsyms = [f for f in os.listdir(search_root) if f.endswith(".dSYM")]
+        dsyms = []
+        for root, dirs, files in os.walk(search_root):
+            dsyms.extend((root, d) for d in dirs if d.endswith(".dSYM"))
+            dsyms.extend((root, f) for f in files if f.endswith(".dSYM"))
+        log.debug("Found %d dsyms", len(dsyms))
 
     tmpf = NamedTemporaryFile(delete=False)
     tmpf.close()
     tar_path = os.path.abspath(tmpf.name + ".tgz")
 
-    os.chdir(search_root)
     tar = tarfile.open(name=tar_path, mode="w:gz")
-    for dsym in dsyms:
+    for root, dsym in dsyms:
+        os.chdir(root)
         log.debug("Adding %s to tar", dsym)
         tar.add(dsym)
     tar.close()


### PR DESCRIPTION
-- Before, we effectively assumed that the dsym folders existed at
the top level of the downloaded archive. However, that isn't always
the case. Some customers have archives containing a single folder, which
in turn contains the dsym folders. In such cases, the upload script
fails to find and upload the symbols, even though they are there.

-- Therefore, we make the script more robust by using os.walk, allowing
us to search the entire symbol archive for dsym folders, rather than
just the top level.

-- Note that because the search_root now no longer necessarily
corresponds to the directory just about each dsym folder, we
change directory to the root of each dsym before adding it to the
tar file for upload. This way, the upload preserves the same
directory structure as before this change.