### PR TITLE
Fix config field name

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ generated `mapping.txt` file manually before any stack traces received from that
    - `configPath "<the path to the flurry.config file described above>"`
    - `apiKey "<the api key used to initialize the SDK>"`
    - `token "<An environment variable to read the token from>"`
-   - `useEnvironmentVariable (true|false)` the default for `useEnvironmentVariable` is `true`. You can set it to `false`
+   - `useEnvVar (true|false)` the default for `useEnvVar` is `true`. You can set it to `false`
      if you want to inline your [Programmatic Token][programmatic-access], though this is not recommended.
    - `ndk (true|false)` the default value is `false`. You can set it to `true` if you want to upload symbols for your native code as well.
 


### PR DESCRIPTION
The config field name is misspelt in the doc.
https://github.com/flurry/upload-clients/blob/60d8cfd9a40887b6b34f59523587abe2a76e7e5e/gradle/src/main/groovy/com/flurry/android/symbols/SymbolUploadConfiguration.groovy#L22