### PR TITLE
SymbolUploadPlugin: factor "variant.resValue" operations prior to project evaluation

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -17,22 +17,14 @@ plugins {
 }
 
 group 'com.flurry'
-version '4.0.0'
+version '4.2.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-String bintrayUser = project.hasProperty("bintray.api.user") ? project.property("bintray.api.user") : ""  // Keep out of source control
-String bintrayApiKey = project.hasProperty("bintray.api.key") ? project.property("bintray.api.key") : ""   // Keep out of source control
-
-logger.lifecycle("Bintray user $bintrayUser")
-
 repositories {
     google()
-    jcenter()
-    maven {
-        url  "http://yahoo.bintray.com/maven"
-    }
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
- See https://issuetracker.google.com/issues/159550502 for a discussion of a similar issue
- Removed unneeded jcenter(), bintray refs
- Update plugin version to 4.2.0, aligning with AGP version numbering