### PR TITLE
update code for gradle version 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ generated `mapping.txt` file manually before any stack traces received from that
        }
       }
       dependencies {
-       classpath "gradle.plugin.com.flurry:symbol-upload:4.2.1"
+       classpath "gradle.plugin.com.flurry:symbol-upload:7.3.0"
       }
      }
    ```
-1. Add the the upload-client plugin in plugins section and the following configuration to the app build.gradle file.
+   The latest symbol upload plugin version is 7.3.0.
+1. Add the upload-client plugin in plugins section and the following configuration to the app build.gradle file.
    ```
    plugins {
       id: "com.flurry.android.symbols"

--- a/README.md
+++ b/README.md
@@ -59,25 +59,24 @@ If you choose not to use FastLane, this can be done manually through the followi
 generated `mapping.txt` file manually before any stack traces received from that version of your app can be deobfuscated.
 
 1. Install Flurry SDK 6.7.0 or greater.
-1. Apply the Flurry android crash plugin to your app's build
+1. Add the Flurry android crash plugin to your project's build.gradle file.
    ```
      buildscript {
       repositories {
        maven {
         url "https://plugins.gradle.org/m2/"
        }
-       maven {
-        url  "http://yahoo.bintray.com/maven"
-       }
       }
       dependencies {
-       classpath "gradle.plugin.com.flurry:symbol-upload:1.2.0"
+       classpath "gradle.plugin.com.flurry:symbol-upload:4.2.1"
       }
      }
-     apply plugin: "com.flurry.android.symbols"
    ```
-1. Configure the crash plugin by adding the following configuration to the build.gradle file.
+1. Add the the upload-client plugin in plugins section and the following configuration to the app build.gradle file.
    ```
+   plugins {
+      id: "com.flurry.android.symbols"
+   }
    flurryCrash {
      apiKey ""
      token ""
@@ -90,6 +89,7 @@ generated `mapping.txt` file manually before any stack traces received from that
    - `useEnvVar (true|false)` the default for `useEnvVar` is `true`. You can set it to `false`
      if you want to inline your [Programmatic Token][programmatic-access], though this is not recommended.
    - `ndk (true|false)` the default value is `false`. You can set it to `true` if you want to upload symbols for your native code as well.
+   - `uploadTimeout 12000` the minimum default timeout value is 60000ms or 1 minute but if you face build failures at uploadProguardMappingFilesRelease stage, try increasing the timeout
 
 [programmatic-access]: https://developer.yahoo.com/flurry/docs/api/code/apptoken/
 [plugin-install]: https://plugins.gradle.org/plugin/com.flurry.android.symbols

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you choose not to use FastLane, this can be done manually through the followi
 generated `mapping.txt` file manually before any stack traces received from that version of your app can be deobfuscated.
 
 1. Install Flurry SDK 6.7.0 or greater.
-1. Add the Flurry android crash plugin to your project's build.gradle file.
+1. Add the Flurry android crash plugin to your project's build.gradle file. Plugin can be found at: [https://plugins.gradle.org/plugin/com.flurry.android.symbols](https://plugins.gradle.org/plugin/com.flurry.android.symbols).
    ```
      buildscript {
       repositories {
@@ -72,7 +72,7 @@ generated `mapping.txt` file manually before any stack traces received from that
       }
      }
    ```
-   The latest symbol upload plugin version is 7.3.0.
+   The latest symbol upload plugin version is 7.3.0. 
 1. Add the upload-client plugin in plugins section and the following configuration to the app build.gradle file.
    ```
    plugins {

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group 'com.flurry'
-version '4.2.0'
+version '4.2.1'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -17,7 +17,7 @@ plugins {
 }
 
 group 'com.flurry'
-version '4.2.1'
+version '7.3.0'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'com.android.tools.build:gradle:[4.2.0,5.0)'
+    compileOnly 'com.android.tools.build:gradle:[4.2.0,7.3.0]'
 
     implementation gradleApi()
     implementation localGroovy()

--- a/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
+++ b/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
@@ -51,13 +51,13 @@ class NdkSymbolUpload {
 
         Closure searchForSharedObjectFiles = { ExternalNativeBuildTask task ->
             if (task.objFolder instanceof DirectoryProperty) {
-               findSharedObjectFiles(task.objFolder.asFileTree.files, addSharedObjectFiles)
-               findSharedObjectFiles(task.soFolder.asFileTree.files, addSharedObjectFiles)
-           }
-           else {
-               findSharedObjectFiles(new HashSet<File>(Set.of(task.objFolder)), addSharedObjectFiles)
-               findSharedObjectFiles(new HashSet<File>(Set.of(task.soFolder)), addSharedObjectFiles)
-           }
+                findSharedObjectFiles(task.objFolder.asFileTree.files, addSharedObjectFiles)
+                findSharedObjectFiles(task.soFolder.asFileTree.files, addSharedObjectFiles)
+            }
+            else {
+                findSharedObjectFiles(Set.of(task.objFolder), addSharedObjectFiles)
+                findSharedObjectFiles(Set.of(task.soFolder), addSharedObjectFiles)
+            }
         }
 
         try {
@@ -83,9 +83,9 @@ class NdkSymbolUpload {
 
     private static void findSharedObjectFiles(Set<File> fileSet, Closure processor) {
         if (fileSet == null) {
-           return;
+            return;
         }
-       for(File dir: fileSet) {
+        for(File dir: fileSet) {
             if (dir.exists()) {
                 dir.eachDir { architecture ->
                     architecture.eachFileMatch(FILES, ~/.*\.so$/, { processor(it) })

--- a/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
+++ b/gradle/src/main/groovy/com/flurry/android/symbols/NdkSymbolUpload.groovy
@@ -84,8 +84,8 @@ class NdkSymbolUpload {
         for(File file: fileSet) {
             if (file.exists()) {
                 if (file.isDirectory()) {
-                    file.eachDir { architecture ->
-                        architecture.eachFileMatch(FILES, ~/.*\.so$/, { processor(it) })
+                    file.eachDir { dir ->
+                        dir.eachFileMatch(FILES, ~/.*\.so$/, { processor(it) })
                     }
                 }
                 else {


### PR DESCRIPTION
The PR solves two bugs:

1. Build failing for Gradle version 7.2.0+ with some Gradle API changes.

> FAILURE: Build failed with an exception. * What went wrong: Execution failed for task ':flurryNativeCrashTestApp:assembleDebug'. > Cannot cast object 'task ':flurryNativeCrashTestApp:externalNativeBuildDebug' property 'objFolder'' with class 'org.gradle.api.internal.file.DefaultFilePropertyFactory$DefaultDirectoryVar' to class 'java.io.File'

2. Metadata query after upload operation times out resulting in project build failure.

> > Task :app:uploadProguardMappingFilesRelease FAILED
> :app:uploadProguardMappingFilesRelease (Thread[Execution worker,5,main]) completed. Took 8.966 secs.
> AAPT2 aapt2-7.1.3-7984345-osx Daemon #0: shutdown
> Android Lint: Disposing Uast application environment in lint classloader [30.1.3]
> 
> FAILURE: Build completed with 2 failures.
> 
> * What went wrong:
> Execution failed for task ':app:uploadProguardMappingFilesRelease'.
> > Upload not processed after 0s

Also removing deprecated code: https://github.com/firebase/firebase-android-sdk/issues/198#issuecomment-461408446 which was deprecated in (com.android.tools.build:gradle:3.3.1)
`WARNING: API 'variant.getExternalNativeBuildTasks()' is obsolete 
and has been replaced with 'variant.getExternalNativeBuildProviders()'.`