### PR TITLE
Fix SSL error in latest versions of Python

### DIFF
--- a/xcode/upload-symbols-py3.py
+++ b/xcode/upload-symbols-py3.py
@@ -49,7 +49,7 @@ UPLOAD_BASE = "https://upload.flurry.com/upload/v1/"
 
 API_KEY = 'api-key'
 TOKEN_KEY = 'token'
-SSL_CONTEXT = ssl.create_default_context(purpose=ssl.Purpose.CLIENT_AUTH)
+SSL_CONTEXT = ssl.create_default_context()
 
 LOG_FORMAT = "%(asctime)s [%(levelname)s] %(filename)s:%(lineno)s	%(message)s"
 logging.basicConfig(format=LOG_FORMAT, datefmt="%H:%M:%S")


### PR DESCRIPTION
This change should fix the following error thrown in latest versions of Python (I believe 3.10+):

```
error looking up project. <urlopen error Cannot create a client socket with a PROTOCOL_TLS_SERVER context (_ssl.c:795)> <class 'urllib.error.URLError'>
```